### PR TITLE
HELP-9523 Implement uploadBlobWithBytes to support WebP images for Bluesky

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = "work.socialhub.kbsky"
-    version = "0.3.0-SNAPSHOT"
+    version = "0.3.3-EBX-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/RepoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/RepoResource.kt
@@ -75,4 +75,13 @@ interface RepoResource {
     fun uploadBlob(
         request: RepoUploadBlobRequest
     ): Response<RepoUploadBlobResponse>
+
+    /**
+     * Upload a new blob using raw bytes with an explicit content type.
+     * Use in place of [uploadBlob] for content types not natively
+     * supported by the underlying HTTP client (e.g. image/webp).
+     */
+    fun uploadBlobWithBytes(
+        request: RepoUploadBlobRequest
+    ): Response<RepoUploadBlobResponse>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_RepoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_RepoResource.kt
@@ -24,6 +24,7 @@ import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoPutRecordResponse
 import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoUploadBlobRequest
 import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoUploadBlobResponse
 import work.socialhub.kbsky.api.entity.share.Response
+import work.socialhub.kbsky.internal.share._InternalUtility.postBytesWithAuth
 import work.socialhub.kbsky.internal.share._InternalUtility.postWithAuth
 import work.socialhub.kbsky.internal.share._InternalUtility.proceed
 import work.socialhub.kbsky.internal.share._InternalUtility.proceedUnit
@@ -146,6 +147,24 @@ class _RepoResource(
                         fileBody = request.bytes
                     )
                     .postWithAuth(request.auth)
+            }
+        }
+    }
+
+    override fun uploadBlobWithBytes(
+        request: RepoUploadBlobRequest
+    ): Response<RepoUploadBlobResponse> {
+
+        return proceed {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, RepoUploadBlob))
+                    .accept(MediaType.JSON)
+                    .postBytesWithAuth(
+                        auth = request.auth,
+                        bytes = request.bytes,
+                        mimeType = request.contentType
+                    )
             }
         }
     }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
@@ -1,7 +1,15 @@
 package work.socialhub.kbsky.internal.share
 
+import io.ktor.client.HttpClient
+import io.ktor.client.request.headers
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod.Companion.Get
 import io.ktor.http.HttpMethod.Companion.Post
+import io.ktor.http.URLBuilder
+import io.ktor.http.content.ByteArrayContent
+import io.ktor.http.takeFrom
 import kotlinx.datetime.TimeZone
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -152,6 +160,60 @@ object _InternalUtility {
         val second = this.post()
         auth.afterRequestHook(method, this, second)
         return second
+    }
+
+    suspend fun HttpRequest.postBytesWithAuth(
+        auth: AuthProvider,
+        bytes: ByteArray,
+        mimeType: String
+    ): HttpResponse {
+        addContentLabelersHeader(auth.acceptLabelers)
+
+        // Populate standard headers into the header map (mirrors khttpclient's proceed())
+        accept?.let { header["Accept"] = it }
+        userAgent?.let { header["User-Agent"] = it }
+
+        val method = Post.value
+        auth.beforeRequestHook(method, this)
+        val first = sendRawBytes(bytes, mimeType)
+        if (!auth.afterRequestHook(method, this, first))
+            return first
+
+        auth.beforeRequestHook(method, this)
+        val second = sendRawBytes(bytes, mimeType)
+        auth.afterRequestHook(method, this, second)
+        return second
+    }
+
+    private suspend fun HttpRequest.sendRawBytes(
+        bytes: ByteArray,
+        mimeType: String
+    ): HttpResponse {
+        val req = this
+        val client = HttpClient {
+            this.followRedirects = req.followRedirect
+        }
+
+        return HttpResponse.from(
+            client.request {
+                this.method = Post
+                this.url.takeFrom(URLBuilder(checkNotNull(req.url)))
+                this.headers {
+                    req.header.forEach { (k, v) ->
+                        // Skip Content-Type from headers; it will be set by ByteArrayContent
+                        if (!k.equals("Content-Type", ignoreCase = true)) {
+                            append(k, v)
+                        }
+                    }
+                }
+                setBody(
+                    ByteArrayContent(
+                        bytes = bytes,
+                        contentType = ContentType.parse(mimeType)
+                    )
+                )
+            }
+        )
     }
 
     private fun HttpRequest.addContentLabelersHeader(acceptLabelers: List<String>) {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
@@ -194,26 +194,30 @@ object _InternalUtility {
             this.followRedirects = req.followRedirect
         }
 
-        return HttpResponse.from(
-            client.request {
-                this.method = Post
-                this.url.takeFrom(URLBuilder(checkNotNull(req.url)))
-                this.headers {
-                    req.header.forEach { (k, v) ->
-                        // Skip Content-Type from headers; it will be set by ByteArrayContent
-                        if (!k.equals("Content-Type", ignoreCase = true)) {
-                            append(k, v)
+        return try {
+            HttpResponse.from(
+                client.request {
+                    this.method = Post
+                    this.url.takeFrom(URLBuilder(checkNotNull(req.url)))
+                    this.headers {
+                        req.header.forEach { (k, v) ->
+                            // Skip Content-Type from headers; it will be set by ByteArrayContent
+                            if (!k.equals("Content-Type", ignoreCase = true)) {
+                                append(k, v)
+                            }
                         }
                     }
-                }
-                setBody(
-                    ByteArrayContent(
-                        bytes = bytes,
-                        contentType = ContentType.parse(mimeType)
+                    setBody(
+                        ByteArrayContent(
+                            bytes = bytes,
+                            contentType = ContentType.parse(mimeType)
+                        )
                     )
-                )
-            }
-        )
+                }
+            )
+        } finally {
+            client.close()
+        }
     }
 
     private fun HttpRequest.addContentLabelersHeader(acceptLabelers: List<String>) {


### PR DESCRIPTION
Adds support for uploading blobs using raw bytes with an explicit content type, for content types not natively supported by the HTTP client (such as `image/webp`). The main changes include introducing a new method in the `RepoResource` interface and implementing the corresponding logic in the internal utility layer to handle raw byte uploads with custom MIME types.

**API Additions:**

* Added `uploadBlobWithBytes` method to the `RepoResource` interface, allowing uploads of blobs using raw bytes and a specified content type.

**Implementation Details:**

* Implemented `uploadBlobWithBytes` in `_RepoResource`, utilizing a new utility function to handle the upload with raw bytes and MIME type.
* Added `postBytesWithAuth` and `sendRawBytes` helper functions in `_InternalUtility.kt` to facilitate authenticated HTTP POST requests with arbitrary byte payloads and content types.
* Updated imports in `_InternalUtility.kt` to include necessary Ktor client components for handling raw byte uploads.

These changes enable more flexible blob uploads, especially for media types not previously supported.